### PR TITLE
Calculate UTC time after deducting/adding offset

### DIFF
--- a/dataProvider.js
+++ b/dataProvider.js
@@ -34,7 +34,9 @@ function twoDigits( value )
 var getMonth = function( number )
 {
     var date = new Date( 1970, parseInt( number ) - 1, 1 );
-    return date.toLocaleString( vscode.env.language, { month: "long" } );
+    var userTimezoneOffset = date.getTimezoneOffset() * 60000;
+    var userDate = new Date(date.getTime() - userTimezoneOffset);
+    return userDate.toLocaleString( vscode.env.language, { month: "long" } );
 }
 
 var getDay = function( date )


### PR DESCRIPTION
The current solution will always work with UTC, which is not good for locations with a negative offset (ahead of UTC), as the current date will always be "yesterday"

I applied the solution I found from https://stackoverflow.com/a/39209842

While this works for me and presumably, will work for you too, I have no idea what happens in the edge cases, which I believe would be the following cases:

* Near or same as UTC offset, and
* with daylight savings time in the areas near UTC